### PR TITLE
Fix bonus search filtering bug

### DIFF
--- a/Bonus.pas
+++ b/Bonus.pas
@@ -143,7 +143,7 @@ end;
 
 if edit1.Text>'' then
 begin
- sSQL := sSQL+ ' and  SAA like '''+edit33.Text+'''';
+  sSQL := sSQL+ ' and  SAA like '''+edit1.Text+'''';
 end;
 
 if DBLookupComboBox1.Text>'' then


### PR DESCRIPTION
## Summary
- correct the input reference when filtering by name in `Bonus.pas`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f6100aa5c832aa7622c33c6591e1d