### PR TITLE
Use edit1 for SAA filtering

### DIFF
--- a/Bonus.pas
+++ b/Bonus.pas
@@ -143,7 +143,7 @@ end;
 
 if edit1.Text>'' then
 begin
- sSQL := sSQL+ ' and  SAA like '''+edit33.Text+'''';
+ sSQL := sSQL+ ' and  SAA like '''+edit1.Text+'''';
 end;
 
 if DBLookupComboBox1.Text>'' then


### PR DESCRIPTION
## Summary
- fix typo in SAA filter clause so the query uses `edit1.Text`

## Testing
- `pytest -q` *(fails: no tests)*
- `make test` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_683f62e558c4832a9d41aa20271ae616