### PR TITLE
Load base file path from config

### DIFF
--- a/Corporation.pas
+++ b/Corporation.pas
@@ -288,6 +288,7 @@ Excel.Selection.Borders.LineStyle := 1;
 Excel.Selection.Borders.Weight := 2;
 Excel.Columns.AutoFit;
 DataModule2.SaveDialog3.FileName:='';
+DataModule2.SaveDialog3.InitialDir := GetBasePath + '3.MED.PERSONAL KARTİ\';
 DataModule2.SaveDialog3.FileName:='Korporativ güzəşt kartları '+datetostr(date())+ '.xlsx';
 if DataModule2.SaveDialog3.Execute() then
 begin

--- a/Datamodule.dfm
+++ b/Datamodule.dfm
@@ -175,9 +175,7 @@
   end
   object SaveDialog3: TSaveDialog
     Filter = 'Excel|*.xlsx'
-    InitialDir = 
-      '\\192.168.0.149\'#351#601'fa mdm\2.QEYRI-R'#399'SM'#304' S'#399'N'#399'DL'#399'R\3.D'#304'SKONT '#350#214'B'#399'S'#304 +
-      '\3.G'#220'Z'#399#350'T KARTLARI\3.MED.PERSONAL KART'#304
+    InitialDir = ''
     Left = 941
     Top = 17
   end

--- a/MainUnit.pas
+++ b/MainUnit.pas
@@ -50,6 +50,8 @@ var
   butsel: integer;
   cfgFile: TIniFile;
 
+function GetBasePath: string;
+
 implementation
 
 {$R *.dfm}
@@ -60,6 +62,20 @@ uses Bonus, Datamodule, NIPT, Patients, Personal, BunusUpload, Corporation,
 const
 msoSendBehindText=3;
 msoTextOrientationHorizontal=1;
+
+function GetBasePath: string;
+const
+  DEFAULT_BASE_PATH = '\\192.168.0.149\şəfa mdm\2.QEYRI-RƏSMİ SƏNƏDLƏR\3.DİSKONT ŞÖBƏSİ\3.GÜZƏŞT KARTLARI\';
+begin
+  cfgFile := TIniFile.Create(ExtractFilePath(ParamStr(0)) + 'config.dat');
+  try
+    Result := cfgFile.ReadString('general', 'BasePath', DEFAULT_BASE_PATH);
+  finally
+    cfgFile.Free;
+  end;
+  if Result = '' then
+    Result := DEFAULT_BASE_PATH;
+end;
 
 procedure TForm1.Bonuskart1Click(Sender: TObject);
 begin

--- a/Patients.pas
+++ b/Patients.pas
@@ -92,7 +92,7 @@ procedure TForm2.Button1Click(Sender: TObject);
 var
 butsel: integer;
 begin
-filename:='\\192.168.0.149\şəfa mdm\2.QEYRI-RƏSMİ SƏNƏDLƏR\3.DİSKONT ŞÖBƏSİ\3.GÜZƏŞT KARTLARI\5.PASİYENT GÜZƏŞT KARTI\';
+filename := GetBasePath + '5.PASİYENT GÜZƏŞT KARTI\';
 DataModule2.SaveDialog1.FileName:=edit2.Text+' '+edit3.Text;
 CreateDir(filename+'\'+DataModule2.SaveDialog1.FileName);
 DataModule2.SaveDialog1.InitialDir := ExtractFilePath(filename+DataModule2.SaveDialog1.FileName+'\');
@@ -296,7 +296,7 @@ procedure TForm2.Button6Click(Sender: TObject);
 var
 butsel : integer;
 begin
-filename:='\\192.168.0.149\şəfa mdm\2.QEYRI-RƏSMİ SƏNƏDLƏR\3.DİSKONT ŞÖBƏSİ\3.GÜZƏŞT KARTLARI\5.PASİYENT GÜZƏŞT KARTI\';
+filename := GetBasePath + '5.PASİYENT GÜZƏŞT KARTI\';
 DataModule2.SaveDialog1.FileName:=edit2.Text+' '+edit3.Text;
 CreateDir(filename+'\'+DataModule2.SaveDialog1.FileName);
 DataModule2.SaveDialog1.InitialDir := ExtractFilePath(filename+DataModule2.SaveDialog1.FileName+'\');

--- a/Personal.pas
+++ b/Personal.pas
@@ -133,6 +133,7 @@ Excel.Selection.Borders.LineStyle := 1;
 Excel.Selection.Borders.Weight := 2;
 Excel.Columns.AutoFit;
 DataModule2.SaveDialog3.FileName:='';
+DataModule2.SaveDialog3.InitialDir := GetBasePath + '3.MED.PERSONAL KARTİ\';
 DataModule2.SaveDialog3.FileName:='Personal güzəşt kartları '+datetostr(date())+ '.xlsx';
 if DataModule2.SaveDialog3.Execute() then
 begin
@@ -276,7 +277,7 @@ DataModule2.ADOQuery6DOB.Value:=strtodate(MaskEdit16.EditText);
 DataModule2.ADOQuery6.Next;
 end;
 DataModule2.ADOQuery6.Next;
-filename:='\\192.168.0.149\şəfa mdm\2.QEYRI-RƏSMİ SƏNƏDLƏR\3.DİSKONT ŞÖBƏSİ\3.GÜZƏŞT KARTLARI\3.MED.PERSONAL KARTİ\';
+filename := GetBasePath + '3.MED.PERSONAL KARTİ\';
 if Length(edit10.Text)=2 then
 begin
 DataModule2.SaveDialog2.FileName:='0'+edit10.Text+'. '+edit11.Text+' '+DBLookupComboBox2.Text;
@@ -500,7 +501,7 @@ end;
 
 procedure TForm3.Button9Click(Sender: TObject);
 begin
-filename:='\\192.168.0.149\şəfa mdm\2.QEYRI-RƏSMİ SƏNƏDLƏR\3.DİSKONT ŞÖBƏSİ\3.GÜZƏŞT KARTLARI\3.MED.PERSONAL KARTİ\';
+filename := GetBasePath + '3.MED.PERSONAL KARTİ\';
 if Length(edit10.Text)=2 then
 begin
 DataModule2.SaveDialog2.FileName:='0'+edit10.Text+' '+edit11.Text+' '+DBLookupComboBox2.Text;


### PR DESCRIPTION
## Summary
- read network base path from `config.dat`
- use `GetBasePath` when saving patient, personal, and corporate cards
- clear hardcoded path from `Datamodule.dfm`

## Testing
- `fpc MainUnit.pas` *(fails: Can't find unit Winapi.Windows)*

------
https://chatgpt.com/codex/tasks/task_e_683f65af7cb4832ab8b82f6c8f933579